### PR TITLE
feat: remove all branches except 'main' or 'master'

### DIFF
--- a/commands/deleteAllBranches.js
+++ b/commands/deleteAllBranches.js
@@ -2,10 +2,10 @@ const childProcess = require("child_process");
 
 module.exports = () => {
   childProcess.exec(
-    'git branch | grep -v "main" | xargs git branch -D',
+    'git branch | grep -v "main\|master" | xargs git branch -D',
     {},
     () => {
-      console.log("=> Removed all branches except 'main':"); // eslint-disable-line no-console
+      console.log("=> Removed all branches except 'main' or 'master':"); // eslint-disable-line no-console
     }
   );
 };

--- a/questions/initial.js
+++ b/questions/initial.js
@@ -11,7 +11,7 @@ module.exports = {
     { name: "Create new branch", value: "newBranch" },
     { name: "Prune remote branches", value: "prune" },
     { name: "Tidy up branches", value: "tidy" },
-    { name: "Remove all branches (except main)", value: "delete" },
+    { name: "Remove all branches (except main or master)", value: "delete" },
     new inquirer.Separator(),
   ],
 };


### PR DESCRIPTION
Most repositories use master instead of main.
Thus, this feature allows git-branch-manager to work with those repositories.